### PR TITLE
add AnalyzeSN submodule; link to djreiss/AnalyzeSN

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "AnalyzeSN"]
+	path = AnalyzeSN
+	url = https://github.com/djreiss/AnalyzeSN.git


### PR DESCRIPTION
This adds a "submodule" that links to repo
https://github.com/djreiss/AnalyzeSN which is a fork of 
rbiswas4/AnalyzeSN.

This is a temporary solution, solely to link the LC fitting and
Hubble diagram plotting notebooks into the Isotropy repo.

Eventually I will sync djreiss/AnalyzeSN with rbiwas4's.